### PR TITLE
Expose rmq connection

### DIFF
--- a/pkg/servicebus/transport/rabbitmq/transport.go
+++ b/pkg/servicebus/transport/rabbitmq/transport.go
@@ -252,3 +252,7 @@ func (rmq *Transport) createIncomingContext(d *amqp.Delivery) *servicebus.Incomi
 	}
 	return ctx
 }
+
+func (rmq *Transport) GetConnection() *amqp.Connection {
+	return rmq.connection
+}


### PR DESCRIPTION
Um den healthcheck zu ermöglich benötigen wir Zugriff auf die Connection.