### PR TITLE
provide CorrelationID and timestamp after publish

### DIFF
--- a/examples/azureservicebus/main.go
+++ b/examples/azureservicebus/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/abecu-hub/go-bus/pkg/servicebus"
 	"github.com/abecu-hub/go-bus/pkg/servicebus/transport/azureservicebus"
-	"os"
 )
 
 type MyMessage struct {
@@ -22,7 +23,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	err = endpoint.SendLocal("MyMessage", &MyMessage{
+	_, err = endpoint.SendLocal("MyMessage", &MyMessage{
 		Message: "Hallo Welt!",
 	})
 	if err != nil {

--- a/examples/rabbitmq/main.go
+++ b/examples/rabbitmq/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/abecu-hub/go-bus/pkg/servicebus"
 	"github.com/abecu-hub/go-bus/pkg/servicebus/retrypolicy"
 	"github.com/abecu-hub/go-bus/pkg/servicebus/transport/rabbitmq"
 	"github.com/google/uuid"
-	"time"
 )
 
 const (
@@ -47,7 +48,7 @@ func main() {
 	}
 
 	for {
-		err = endpoint.SendLocal(CreateUserMessage, &CreateUser{
+		_, err = endpoint.SendLocal(CreateUserMessage, &CreateUser{
 			Name:  "UserName",
 			Email: "username@useremail.com",
 		})

--- a/examples/sagas/main.go
+++ b/examples/sagas/main.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"reflect"
+	"time"
+
 	"github.com/abecu-hub/go-bus/pkg/servicebus"
 	"github.com/abecu-hub/go-bus/pkg/servicebus/saga/mongodb"
 	"github.com/abecu-hub/go-bus/pkg/servicebus/transport/rabbitmq"
@@ -10,8 +13,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"reflect"
-	"time"
 )
 
 const (
@@ -118,7 +119,7 @@ func main() {
 		panic("Error starting DeliveryService endpoint!")
 	}
 
-	err = orderServiceEndpoint.SendLocal(StartOrderMessage, &StartOrder{OrderID: uuid.New().String()})
+	_, err = orderServiceEndpoint.SendLocal(StartOrderMessage, &StartOrder{OrderID: uuid.New().String()})
 	if err != nil {
 		panic("Error sending initial message!")
 	}

--- a/pkg/servicebus/context.go
+++ b/pkg/servicebus/context.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/abecu-hub/go-bus/pkg/servicebus/saga"
 	"time"
+
+	"github.com/abecu-hub/go-bus/pkg/servicebus/saga"
 )
 
 type OutgoingMessageContext struct {
@@ -96,7 +97,7 @@ func (context *IncomingMessageContext) Reply(messageType string, msg interface{}
 		m.CorrelationId = context.CorrelationId
 		m.CorrelationTimestamp = context.CorrelationTimestamp
 	})
-	err := context.endpoint.Send(messageType, origin, msg, options...)
+	_, err := context.endpoint.Send(messageType, origin, msg, options...)
 	if err != nil {
 		return err
 	}
@@ -111,7 +112,7 @@ func (context *IncomingMessageContext) Send(messageType string, destination stri
 		m.CorrelationId = context.CorrelationId
 		m.CorrelationTimestamp = context.CorrelationTimestamp
 	})
-	err := context.endpoint.Send(messageType, destination, msg, options...)
+	_, err := context.endpoint.Send(messageType, destination, msg, options...)
 	if err != nil {
 		return err
 	}
@@ -126,7 +127,7 @@ func (context *IncomingMessageContext) Publish(messageType string, msg interface
 		m.CorrelationId = context.CorrelationId
 		m.CorrelationTimestamp = context.CorrelationTimestamp
 	})
-	err := context.endpoint.Publish(messageType, msg, options...)
+	_, err := context.endpoint.Publish(messageType, msg, options...)
 	if err != nil {
 		return err
 	}
@@ -141,7 +142,7 @@ func (context *IncomingMessageContext) SendLocal(messageType string, msg interfa
 		m.CorrelationId = context.CorrelationId
 		m.CorrelationTimestamp = context.CorrelationTimestamp
 	})
-	err := context.endpoint.SendLocal(messageType, msg, options...)
+	_, err := context.endpoint.SendLocal(messageType, msg, options...)
 	if err != nil {
 		return err
 	}

--- a/pkg/servicebus/endpoint_test.go
+++ b/pkg/servicebus/endpoint_test.go
@@ -48,7 +48,7 @@ func TestCreateOutgoingContext(t *testing.T) {
 	serviceName := "ServiceName"
 	endpoint := Create(serviceName, &TestTransport{}).(*ServiceBusEndpoint)
 	payload := &MyMessage{Name: "HelloWorld"}
-	ctx := endpoint.createMessageContext("MyMessage", payload, nil)
+	_, ctx := endpoint.createMessageContext("MyMessage", payload, nil)
 	if ctx.Origin != serviceName {
 		t.Errorf("Origin not set!")
 	}
@@ -91,7 +91,7 @@ func TestMutateOutgoingContext(t *testing.T) {
 	}
 
 	payload := &MyMessage{Name: "HelloWorld"}
-	ctx := endpoint.createMessageContext(messageName, payload, []OutgoingMutation{mutationHeader, mutationOverride})
+	_, ctx := endpoint.createMessageContext(messageName, payload, []OutgoingMutation{mutationHeader, mutationOverride})
 
 	if ctx.Origin != "NewOrigin" {
 		t.Errorf("Mutation in message configuration failed.")


### PR DESCRIPTION
Hi, Andrè.
We need the CorrelationID and Timestamp when we trigger a new event, e.g. B. for tracking.
Kind regards,
Beppo